### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides accessibility testing capabilities through a command-line interface. This tool helps identify accessibility issues in web applications using axe-core and Puppeteer.
 
+<a href="https://glama.ai/mcp/servers/mik2l7a1tw">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/mik2l7a1tw/badge" alt="Cursor A11y MCP server" />
+</a>
+
 ## Features
 
 - Run accessibility tests on any URL or local development server


### PR DESCRIPTION
This PR adds a badge for the [Cursor A11y MCP](https://glama.ai/mcp/servers/mik2l7a1tw) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/mik2l7a1tw">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/mik2l7a1tw/badge" alt="Cursor A11y MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.